### PR TITLE
Normalize import's event.uri property. Fixes CP-23.

### DIFF
--- a/lib/collapsify.js
+++ b/lib/collapsify.js
@@ -375,8 +375,8 @@ var collapsify = exports.collapsify = function( resourceRoot, options ) {
 			} );
 
 			parser.addListener( 'import', function( event ) {
-
-				var importedStylesheetFlattens = flattenExternalStylesheet( relative( resourceLocation, event.uri ), true );
+				var uri = event.uri.replace( /^(?:url\()?["']?([^"']+?)["']?\)?$/, "$1" );
+				var importedStylesheetFlattens = flattenExternalStylesheet( relative( resourceLocation, uri ), true );
 
 				compilationQueue = compilationQueue.then( function( stylesheet ) {
 


### PR DESCRIPTION
This can be reverted once nzakas/parser-lib#111 gets pulled and released
