### PR TITLE
Utilize `bunyan` to structure server and CLI logging.

### DIFF
--- a/bin/collapsify.js
+++ b/bin/collapsify.js
@@ -64,6 +64,7 @@ if (argv.H) {
   }, {});
 }
 
+var logger = argv.logger = require('../lib/utils/logger')(argv);
 utility.verbosity = argv.v;
 
 if (cluster.isMaster && argv.w > 0) {
@@ -72,7 +73,7 @@ if (cluster.isMaster && argv.w > 0) {
 
     worker.on('exit', function() {
 
-      utility.error('Worker ' + worker.pid + ' died. Attempting to respawn..');
+      logger.error('Worker %s died. Attempting to respawn…', worker.pid);
       cluster.fork();
     });
   });

--- a/lib/collapsify.js
+++ b/lib/collapsify.js
@@ -57,7 +57,7 @@ exports.collapsify = function(resourceRoot, options) {
   };
   var flattenExternalHTML = function(resourceLocation) {
 
-    utility.log('Getting HTML from ' + resourceLocation);
+    options.logger.info('Getting HTML from %s', resourceLocation);
 
     return read(resourceLocation).then(flattenHTML);
   };
@@ -74,13 +74,13 @@ exports.collapsify = function(resourceRoot, options) {
       } else {
         (function append(elements) {
 
-          utility.log('Appending ' + elements.length + ' elements: ' + elements.map(function(element) {
+          options.logger.info('Appending %d elements: %j', elements.length, elements.map(function(element) {
             return element.name || element.type;
-          }).join(', '));
+          }));
 
           elements.forEach(function(element) {
 
-            utility.log('Handling ' + (element.name || element.type));
+            options.logger.info('Handling %s', element.name || element.type);
 
             var elementQueue = Q('');
             var elementText = '';
@@ -103,7 +103,7 @@ exports.collapsify = function(resourceRoot, options) {
 
                 if (!(('attribs' in element) && element.attribs.src ) && 'children' in element && (typeof element.children[0] !== 'undefined' && element.children[0].type === 'text')) {
 
-                  utility.log('Handling inline script text!');
+                  options.logger.info('Handling inline script text!');
 
                   elementQueue = flattenJavaScript(element.children[0].data);
                 }
@@ -295,7 +295,7 @@ exports.collapsify = function(resourceRoot, options) {
   };
   var flattenExternalJavaScript = function(resourceLocation) {
 
-    utility.log('Fetching JavaScript from ' + resourceLocation);
+    options.logger.info('Fetching JavaScript from %s.', resourceLocation);
 
     return read(resourceLocation).then(flattenJavaScript);
   };
@@ -310,7 +310,7 @@ exports.collapsify = function(resourceRoot, options) {
       }).code;
     } catch ( e ) {
 
-      utility.log('Failed to minify some JavaScript. ' + e.message);
+      options.logger.info('Failed to minify some JavaScript: ', e);
 
       return '';
     }
@@ -321,7 +321,7 @@ exports.collapsify = function(resourceRoot, options) {
       return resourceLocation;
     }
 
-    utility.log('Fetching binary from ' + resourceLocation);
+    options.logger.info('Fetching binary from %s.', resourceLocation);
 
     return read(resourceLocation).then(function(rawBinary) {
 
@@ -331,7 +331,7 @@ exports.collapsify = function(resourceRoot, options) {
   });
   var flattenExternalStylesheet = function(resourceLocation, imported) {
 
-    utility.log('Fetching Stylesheet from ' + (resourceLocation || 'inline node.'));
+    options.logger.info('Fetching Stylesheet from %s.', resourceLocation || 'inline node');
 
     return read(resourceLocation).then(function(rawCSS) {
 
@@ -340,7 +340,7 @@ exports.collapsify = function(resourceRoot, options) {
   };
   var flattenStylesheet = function(rawCSS, resourceLocation, imported) {
 
-    utility.log('Flattening raw CSS from ' + (resourceLocation || 'inline style'));
+    options.logger.info('Flattening raw CSS from %s.', resourceLocation || 'inline style');
 
     var result = defer();
     var parser = new parserlib.css.Parser({
@@ -536,7 +536,7 @@ exports.collapsify = function(resourceRoot, options) {
 
     parser.addListener('error', function(error) {
 
-      utility.log('Error while parsing CSS in ' + (resourceLocation || resourceRoot) + ': ' + error.message);
+      options.logger.info('Error while parsing CSS in %s: ', resourceLocation || resourceRoot, error);
     });
 
     try {
@@ -545,7 +545,7 @@ exports.collapsify = function(resourceRoot, options) {
 
     } catch ( e ) {
 
-      utility.log('Failed to parse CSS. ' + e.message);
+      options.logger.info('Failed to parse CSS: ', e);
       result.resolve('');
 
     }
@@ -560,7 +560,7 @@ exports.collapsify = function(resourceRoot, options) {
 
   return flattenExternalHTML(resourceRoot).then(function(flattened) {
 
-    utility.log('Final collapsed page is ' + flattened.length + ' bytes.');
+    options.logger.info('Final collapsed page is %d bytes', flattened.length);
     return flattened;
   });
 };

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -1,5 +1,4 @@
 'use strict';
-var fs = require('q-io/fs');
 var he = require('he');
 var restler = require('restler');
 var Q = require('q');
@@ -30,18 +29,6 @@ Object.defineProperty(exports, 'headers', {
 
 exports.isBase64 = function(string) {
   return /^['"]?data:[^;]*;base64/.test(string);
-};
-
-exports.log = function() {
-  if (verbose > 1) {
-    console.log.apply(console, arguments);
-  }
-};
-
-exports.error = function() {
-  if (verbose) {
-    console.error.apply(console, arguments);
-  }
 };
 
 exports.dataToURL = Q.fbind(function(data, type) {

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,0 +1,16 @@
+'use strict';
+var bunyan = require('bunyan');
+
+module.exports = function(options) {
+  var levels = [
+    'warn',
+    'info',
+    'debug'
+  ];
+  var logger = bunyan.createLogger({
+    name: 'collapsify',
+    level: levels[options.v] || 'warn'
+  });
+
+  return logger;
+};

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "Andrew Galloni <andrew@cloudflare.com>"
   ],
   "dependencies": {
+    "bunyan": "^1.3.2",
     "clean-css": "^2.1.6",
     "express": "^3.4.4",
     "he": "^0.3.6",
     "htmlparser2": "^3.5.1",
     "parserlib": "^0.2.3",
     "q": "^1.0.1",
-    "q-io": "^1.11.0",
     "restler": "^3.2.0",
     "uglify-js": "^2.4.1",
     "yargs": "^1.2.1"


### PR DESCRIPTION
Starting to replace our `console.log` based logging with `bunyan` to
help structure our logs across multiple levels, and in the future change
where logs are written based on options passed, and how Collapsify is
invoked.

For example, when invoked as a CLI tool, we can display logs in a human
readable fashion, but when invoked as part of a server, we can write the
logs in a machine-readable fashion to syslogd.

As a transition point, this commit migrates our current logging to using
`bunyan`, but continuing to output on stdout. The lack of an option
passed to "v" now defaults to outputting on log level "warn". "1" now
corresponds to "info" and "2" is now "debug".