### PR TITLE
fix(css): inline style imports relative to resourceRoot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
 language: node_js
+sudo: false
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 node_js:
-  - "0.12"
-  - "0.10"
-  - "iojs"
+  - 0.12
+  - 0.10
+  - 4.0

--- a/lib/collapsify.js
+++ b/lib/collapsify.js
@@ -371,7 +371,7 @@ module.exports = function(resourceRoot, options) {
 
     parser.addListener('import', function(event) {
       var uri = event.uri.replace(/^(?:url\()?["']?([^"']+?)["']?\)?$/, '$1');
-      var importedStylesheetFlattens = flattenExternalStylesheet(relative(resourceLocation, uri), true);
+      var importedStylesheetFlattens = flattenExternalStylesheet(relative(resourceLocation || resourceRoot, uri), true);
 
       compilationQueue = compilationQueue.then(function(stylesheet) {
 


### PR DESCRIPTION
Inline styles can import other CSS with an `@import` rule. These rules
were being flattened relative to the style resource's location. For
inline styles, there is not a defined resource location, so we should
resolve relative to the root document.