### PR TITLE
Skip empty src URLs in CSS declarations

### DIFF
--- a/lib/utils/css-url.js
+++ b/lib/utils/css-url.js
@@ -3,6 +3,10 @@ const dataURI = require('../utils/data-uri');
 
 module.exports = (node, skipCheck) => {
   if (node.type === 'function' && node.value === 'url') {
+    if (node.nodes.length === 0) {
+      return;
+    }
+
     node = node.nodes[0];
     skipCheck = true;
   }

--- a/test/plugins/postcss-flatten-url.js
+++ b/test/plugins/postcss-flatten-url.js
@@ -21,6 +21,13 @@ describe('postcss-flatten-url', () => {
     );
   });
 
+  it('should ignore empty src URLs', () => {
+    return test(
+      '@font-face { font-family: Noto Sans; src: url() format("opentype"); }',
+      '@font-face { font-family: Noto Sans; src: url() format("opentype"); }'
+    );
+  });
+
   it('should replace the URL in a property', () => {
     return test(
       '.flatten { background: url("example.png") }',


### PR DESCRIPTION
Hi,

For some reason some generators/systems output invalid CSS URLs for font-faces. Although incorrect, this is safe as browsers will simply ignore the declaration.

This PR adds support for collapsifying a page which contains this invalid content by ignoring its inexistent URL source.