### PR TITLE
Add error messages

### DIFF
--- a/src/collapsers/javascript.ts
+++ b/src/collapsers/javascript.ts
@@ -1,6 +1,6 @@
 import {minify} from 'terser';
 import bole from 'bole';
-import {CollapsifyOptions} from '../collapsify.js';
+import {CollapsifyError, CollapsifyOptions} from '../collapsify.js';
 
 const logger = bole('collapsify:collapsers:javascript');
 

--- a/src/collapsify.ts
+++ b/src/collapsify.ts
@@ -1,10 +1,13 @@
 import type {Buffer} from 'node:buffer';
 
-export {external as default} from './collapsers/html.js';
+import {external as htmlCollapser} from './collapsers/html.js';
+import {fetchWrapper} from './utils/fetch-wrapper.js';
 
 export class CollapsifyError extends Error {}
 
 export interface Response {
+  getStatusCode(): number;
+
   getContentType(): string;
 
   getAsString(): Promise<string>;
@@ -17,4 +20,11 @@ export type Fetch = (url: string) => Promise<Response>;
 export interface CollapsifyOptions {
   resourceLocation: string;
   fetch: Fetch;
+}
+
+export default async function collapsify(options: CollapsifyOptions) {
+  return htmlCollapser({
+    resourceLocation: options.resourceLocation,
+    fetch: fetchWrapper(options.fetch),
+  });
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,6 +1,6 @@
 import type {Headers} from 'got';
 import httpClient from './utils/httpclient.js';
-import collapseHTML from './collapsify.js';
+import collapseHTML, {CollapsifyError} from './collapsify.js';
 
 interface NodeOptions {
   forbidden?: string;
@@ -24,7 +24,7 @@ export default async function collapsifyNode(
     const re = new RegExp(options.forbidden, 'i');
 
     if (re.test(url)) {
-      throw new Error('Forbidden resource ' + url);
+      throw new CollapsifyError('Forbidden resource ' + url);
     }
 
     return fetch(url);

--- a/src/utils/fetch-wrapper.ts
+++ b/src/utils/fetch-wrapper.ts
@@ -1,0 +1,60 @@
+import type {Buffer} from 'node:buffer';
+import bole from 'bole';
+import {CollapsifyError, Fetch, Response} from '../collapsify.js';
+
+const logger = bole('collapsify:fetch');
+
+export function fetchWrapper(fetch: Fetch): Fetch {
+  return async (url) => {
+    try {
+      const response = await fetch(url);
+      if (response.getStatusCode() >= 300) {
+        throw new CollapsifyError(
+          `Fetch failed, ${url} returned ${response.getStatusCode()}`,
+        );
+      }
+
+      return new ResponseWrapper(url, response);
+    } catch (error: unknown) {
+      if (error instanceof CollapsifyError) {
+        throw error;
+      }
+
+      logger.error(error);
+      throw new CollapsifyError(`Fetch failed, ${url} unknown error occured`);
+    }
+  };
+}
+
+class ResponseWrapper implements Response {
+  constructor(
+    private readonly url: string,
+    private readonly response: Response,
+  ) {}
+
+  getStatusCode(): number {
+    return this.response.getStatusCode();
+  }
+
+  getContentType(): string {
+    return this.response.getContentType();
+  }
+
+  async getAsString(): Promise<string> {
+    try {
+      return await this.response.getAsString();
+    } catch (error: unknown) {
+      logger.error(error);
+      throw new CollapsifyError(`Couldn't read ${this.url} as string`);
+    }
+  }
+
+  async getAsArray(): Promise<Buffer> {
+    try {
+      return await this.response.getAsArray();
+    } catch (error: unknown) {
+      logger.error(error);
+      throw new CollapsifyError(`Couldn't read ${this.url} as binary`);
+    }
+  }
+}

--- a/src/utils/httpclient.ts
+++ b/src/utils/httpclient.ts
@@ -11,9 +11,14 @@ const logger = bole('collapsify:http');
 
 class GotResponse implements Response {
   constructor(
+    private readonly statusCode: number,
     private readonly contentType: string,
     private readonly buffer: Buffer,
   ) {}
+
+  getStatusCode(): number {
+    return this.statusCode;
+  }
 
   getContentType(): string {
     return this.contentType;
@@ -57,7 +62,11 @@ export default function makeClient(defaultHeaders: Headers): Fetch {
       logger.debug('Retrieved %s from cache.', url);
     }
 
-    return new GotResponse(response.headers['content-type'], response.rawBody);
+    return new GotResponse(
+      response.statusCode,
+      response.headers['content-type'],
+      response.rawBody,
+    );
   }
 
   return gotFetch;

--- a/test/collapsers/css.js
+++ b/test/collapsers/css.js
@@ -3,6 +3,7 @@ import assert from 'power-assert';
 import {describe, it} from 'mocha';
 import {binaryResponse} from '../helpers.js';
 import collapser from '../../built/collapsers/css.js';
+import {CollapsifyError} from '../../built/collapsify.js';
 
 describe('CSS collapser', () => {
   it('should minify CSS', async () => {
@@ -28,8 +29,24 @@ describe('CSS collapser', () => {
 
       assert(false, 'unexpect Promise resolution');
     } catch (error) {
-      assert(!(error instanceof assert.AssertionError));
-      assert(error.reason === 'Unclosed block');
+      assert(error instanceof CollapsifyError, 'wrong error type');
+      assert.equal(error.message, 'Error during CSS inlining.');
+    }
+  });
+
+  it('fetch error message returned', async () => {
+    try {
+      await collapser(`html, body { background: url('something.jpg'); }`, {
+        fetch() {
+          throw new CollapsifyError('Error from fetch');
+        },
+        resourceLocation: 'https://example.com',
+      });
+
+      assert(false, 'unexpect Promise resolution');
+    } catch (error) {
+      assert(error instanceof CollapsifyError, 'wrong error type');
+      assert.equal(error.message, 'Error from fetch');
     }
   });
 

--- a/test/node.js
+++ b/test/node.js
@@ -2,6 +2,7 @@ import assert from 'power-assert';
 import nock from 'nock';
 import {describe, it} from 'mocha';
 import collapsify from '../built/node.js';
+import {CollapsifyError} from '../built/collapsify.js';
 
 nock.disableNetConnect();
 
@@ -38,8 +39,8 @@ describe('collapsify node', () => {
 
       assert(false, 'unexpected Promise resolution');
     } catch (error) {
-      assert(error instanceof Error);
-      assert(error.message === 'Forbidden resource http://localhost/');
+      assert(error instanceof CollapsifyError, 'wrong error type');
+      assert.equal(error.message, 'Forbidden resource http://localhost/');
     }
   });
 });

--- a/test/utils/fetch-wrapper.js
+++ b/test/utils/fetch-wrapper.js
@@ -1,0 +1,96 @@
+import {Buffer} from 'node:buffer';
+import assert from 'power-assert';
+import {describe, it} from 'mocha';
+import {CollapsifyError} from '../../built/collapsify.js';
+import {fetchWrapper} from '../../built/utils/fetch-wrapper.js';
+
+describe('fetch-wrapper', () => {
+  it('bad status code throws error', async () => {
+    try {
+      await fetchWrapper(() => new FakeResponse({statusCode: 404}))(
+        'http://exmaple.com',
+      );
+      assert.fail('should have thrown');
+    } catch (error) {
+      assertError(error, 'Fetch failed, http://exmaple.com returned 404');
+    }
+  });
+
+  it('failed getAsString', async () => {
+    try {
+      const response = await fetchWrapper(
+        () => new FakeResponse({text: Promise.reject()}),
+      )('http://exmaple.com');
+      await response.getAsString();
+      assert.fail('should have thrown');
+    } catch (error) {
+      assertError(error, `Couldn't read http://exmaple.com as string`);
+    }
+  });
+
+  it('failed getAsArray', async () => {
+    try {
+      const response = await fetchWrapper(
+        () => new FakeResponse({text: Promise.reject()}),
+      )('http://exmaple.com');
+      await response.getAsArray();
+      assert.fail('should have thrown');
+    } catch (error) {
+      assertError(error, `Couldn't read http://exmaple.com as binary`);
+    }
+  });
+
+  it('can read properties', async () => {
+    const response = await fetchWrapper(
+      () =>
+        new FakeResponse({
+          statusCode: 200,
+          contentType: 'text/plain',
+          text: Promise.resolve('some text'),
+          binary: Buffer.from([0x01, 0x02]),
+        }),
+    )('http://exmaple.com');
+    assert.equal(response.getStatusCode(), 200);
+    assert.equal(response.getContentType(), 'text/plain');
+    assert.equal(await response.getAsString(), 'some text');
+    assert(
+      Buffer.from([0x01, 0x02]).equals(await response.getAsArray()),
+      'array response equal',
+    );
+  });
+});
+
+function assertError(error, message, type = CollapsifyError) {
+  assert(error instanceof type, 'incorrect error type');
+  assert.equal(error.message, message);
+}
+
+class FakeResponse {
+  constructor({
+    statusCode = 200,
+    contentType = '',
+    text = Promise.reject(),
+    binary = Promise.reject(),
+  }) {
+    this.statusCode = statusCode;
+    this.contentType = contentType;
+    this.text = text;
+    this.binary = binary;
+  }
+
+  getStatusCode() {
+    return this.statusCode;
+  }
+
+  getContentType() {
+    return this.contentType;
+  }
+
+  getAsString() {
+    return this.text;
+  }
+
+  getAsArray() {
+    return this.binary;
+  }
+}


### PR DESCRIPTION
Add specific error messages for css failing, or for fetch failing, or returning a response body that can't be understood.

These errors have their own type so it can be caught by callers and displayed to end users safely.