### PR TITLE
Fix inline CSS parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "collapsify",
   "description": "Inlines all of the JavaScripts, stylesheets, images, fonts etc. of an HTML page.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Terin Stock <terinjokes@gmail.com> (http://terinstock.com)",
   "type": "module",
   "bin": {

--- a/src/plugins/html-flatten-inline-style.ts
+++ b/src/plugins/html-flatten-inline-style.ts
@@ -6,13 +6,22 @@ export default function flattenInlineStyle(
   rewriter: HTMLRewriter,
   options: CollapsifyOptions,
 ) {
+  let currentText = '';
   rewriter.on('style', {
     async text(text) {
-      const content = await collapseCSS(text.text, {
+      if (!text.lastInTextNode) {
+        currentText += text.text;
+        text.remove();
+        return;
+      }
+
+      const content = await collapseCSS(currentText, {
         imported: false,
         fetch: options.fetch,
         resourceLocation: options.resourceLocation,
       });
+
+      currentText = '';
 
       if (typeof content !== 'string') {
         throw new TypeError('Wrong output from collapseCSS');

--- a/test/collapsers/html.js
+++ b/test/collapsers/html.js
@@ -66,4 +66,55 @@ describe('html collapser', () => {
         '<!doctype html><html><body><h1>Hi.</h1><img src="data:image/jpeg;base64,"></body></html>',
     );
   });
+
+  // Over 1kb the text is split into multiple chunks
+  it('testing inline style block greater than 1kb', async () => {
+    const bigContent = Array.from({length: 2048}).fill('a').join('');
+    const collapsed = await collapser(
+      `<html><style>
+      body {
+        background: blue;
+        content: '${bigContent}';
+      }
+      </style></html>`,
+      {
+        async fetch() {
+          assert.fail('no request expected');
+        },
+        resourceLocation: 'https://example.com',
+      },
+    );
+
+    assert.equal(typeof collapsed, 'string');
+    assert.equal(
+      collapsed,
+      `<html><style>body{background:blue;content:"${bigContent}"}</style></html>`,
+    );
+  });
+
+  // Over 1kb the text is split into multiple chunks
+  it('testing inline script block greater than 1kb', async () => {
+    const bigContent = Array.from({length: 2048}).fill('a').join('');
+    const collapsed = await collapser(
+      `<html><body><script>
+        function someFunc() {
+          return {
+            content: '${bigContent}'
+          };
+        }
+      </script></html>`,
+      {
+        async fetch() {
+          assert.fail('no request expected');
+        },
+        resourceLocation: 'https://example.com',
+      },
+    );
+
+    assert.equal(typeof collapsed, 'string');
+    assert.equal(
+      collapsed,
+      `<html><body><script>function someFunc(){return{content:"${bigContent}"}}</script></html>`,
+    );
+  });
 });


### PR DESCRIPTION
The html parser breaks text blocks into 1kb chunks, the inline css
parser needs to collect all these blocks then parse them as a single
large bit of css.